### PR TITLE
Debian is supported, too

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ define fstab(
   }
 
   case $::operatingsystem {
-    redhat, centos, amazon: {
+    redhat, debian, centos, amazon: {
       fstab::augeas { $name:
         ensure => $ensure,
         source => $source,


### PR DESCRIPTION
I've tried out your module on Debian, and it modifies the fstab modified as desired. In addition, I've Googled around, and [Debian’s fstab format](http://wiki.debian.org/fstab) is the same as [Red Hat’s](https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Introduction_To_System_Administration/s2-storage-mount-fstab.html).
