### PR TITLE
Repair fstab::augeas for ensure absent.

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -8,6 +8,7 @@ define fstab::augeas(
   $dump   = 0,
   $passno = 0,
   $ensure = 'present'){
+  $fstab_match_line = "*[spec='${source}' and file='${dest}']"
 
   case $ensure {
     'present': {

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,3 +1,5 @@
+include fstab::variables
+
 # fstab module test resources.
 
 fstab { 'A test fstab entry':
@@ -41,6 +43,7 @@ fstab {'AWS Root Drive':
 }
 
 fstab {'Revert AWS Root Drive':
+  ensure  => absent,
   source  => 'LABEL=cloudimg-rootfs',
   dest    => '/',
   type    => 'ext4',
@@ -48,4 +51,11 @@ fstab {'Revert AWS Root Drive':
   dump    => 0,
   passno  => 0,
   require => Fstab['AWS Root Drive'],
+}
+
+fstab { 'remove proc':
+  ensure => absent,
+  source => 'proc',
+  dest   => '/proc',
+  type   => 'proc',
 }


### PR DESCRIPTION
Define fstab_match_line in fstab::augeas too as it is used if
ensure is absent.

Tune smoke tests to confirm.

This closes issue #9.
