### PR TITLE
Add missing include for fstab::variables

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -9,6 +9,9 @@ define fstab::augeas(
   $passno = 0,
   $ensure = 'present'){
 
+  # Get the fstab_file for this OS
+  include fstab::variables
+
   case $ensure {
     'present': {
 


### PR DESCRIPTION
Main augeas.pp was missing include so got error about fstab_file when using ensure => absent
I needed the recent commit from qha also to get tests to pass with this.
